### PR TITLE
Makefile portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,4 @@ $(book).pdf: $(book).epub
 clean:
 	rm -f $(book).{pdf,epub,mobi}
 
+.PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash
+
 book = yourbookname
 chapters = $(shell cat chapters.txt)
 


### PR DESCRIPTION
Couple of tweaks to the Makefile, one to mark the `clean` target as `PHONY` and another to ensure that the Bash shell is used (without this `make clean` does not work on Ubuntu and other systems where `/bin/sh` is not Bash).
